### PR TITLE
Fixing a link in a README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ EVE aims to develop an open, agnostic and standardized architecture unifying the
 
 EVE supports both ARM and Intel architectures and requires hardware-assisted virtualization. While EVE can run on a board as small as a $20 Orange Pi, the sweet spot for its deployment are IoT Gateways and Industrial PCs.
 
-To get its job done, EVE leverages a lot of great open source projects: [Xen Project](https://xenproject.org/), [Linuxkit](https://github.com/linuxkit/linuxkit) and [Alpine Linux](https://alpinelinux.org/) just to name a few. All of that functionality is being orchestrated by the Go microservices available under [pkg/pillar](../pkg/pillar). Why pillar? Well, because pillar is the kind of a monolith we need to break out into true, individual microservices under [pkg/](../pkg/).
+To get its job done, EVE leverages a lot of great open source projects: [Xen Project](https://xenproject.org/), [Linuxkit](https://github.com/linuxkit/linuxkit) and [Alpine Linux](https://alpinelinux.org/) just to name a few. All of that functionality is being orchestrated by the Go microservices available under [pkg/pillar](pkg/pillar). Why pillar? Well, because pillar is the kind of a monolith we need to break out into true, individual microservices under [pkg/](pkg/).
 
 # How to use
 
@@ -83,6 +83,8 @@ from containerd - use that instead).
 
 Once in a container you can run the usual xl commands to start VMs and
 interact with Xen.
+
+# How to use on an ARM board
 
 While running everything on your laptop with qemu could be fun, nothing
 beats real hardware. The most cost-effective option, not surprisingly,


### PR DESCRIPTION
Turns out relative paths (like ../xxx) don't work in markdown docs (and besides they were not even needed in this particular case).