### PR TITLE
Add .go/ cache directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ pkg/mkconf/Dockerfile
 pkg/pillar/Dockerfile
 pkg/qrexec-dom0/Dockerfile
 pkg/qrexec-lib/Dockerfile
+.go/


### PR DESCRIPTION
Signed-off-by: Avi Deitcher <avi@deitcher.net>

It is just a cache directory, so should be in gitignore.