### PR TITLE
Run go vet/fmt before go install for faster fails

### DIFF
--- a/pkg/pillar/Dockerfile.in
+++ b/pkg/pillar/Dockerfile.in
@@ -19,12 +19,12 @@ RUN [ -z "$GOARCH" ] || (cd / ; apk add --no-cache wget && wget -O - $CROSS_GCC 
 
 ADD ./  /go/src/github.com/zededa/eve/pkg/pillar/
 
-# go install and go vet
+# go vet/format and go install
 RUN [ -z "$GOARCH" ] || export CC=$(echo /*-cross/bin/*-gcc)           ;\
-    go install github.com/zededa/eve/pkg/pillar/zedbox/... && \
     echo "Running go vet" && go vet ./... && \
     echo "Running go fmt" && ERR=$(gofmt -e -l -s $(find . -name \*.go | grep -v /vendor/)) && \
        if [ -n "$ERR" ] ; then echo $ERR ; exit 1 ; fi && \
+    go install github.com/zededa/eve/pkg/pillar/zedbox/... && \
     if [ -f /go/bin/*/zedbox ] ; then mv /go/bin/*/zedbox /go/bin ; fi
 
 FROM alpine:3.8


### PR DESCRIPTION
Signed-off-by: Avi Deitcher <avi@deitcher.net>

The pillar build process runs `go install` _before_ `go vet` and `go fmt`. Since `go install` can take much longer, and `go vet`/`go fmt` run against the source, the order doesn't matter. We should run the faster one first so we get quicker failures.