### PR TITLE
[WIP] Document api

### DIFF
--- a/api/API.md
+++ b/api/API.md
@@ -1,0 +1,132 @@
+# API
+
+This document defines the API for Device to Controller communications.
+
+## Definitions
+
+1. `Device`: an independent 
+
+* zmet: device -> controller
+* zconfig: controller -> device
+
+## API endpoints
+
+* `POST /api/v1/edgedevice/register` for device onboarding. Returns one of the following:
+    * `201` - successful registration. 
+    * 
+* `GET /api/v1/edgedevice/ping` for connectivity test; return `200`, empty message, ignores payload
+* `GET /api/v1/edgedevice/config` complete device + instance config
+* `POST /api/v1/edgedevice/info` for triggered device/instance status
+* `POST /api/v1/edgedevice/metrics` for periodic device/instance metrics
+* `POST /api/v1/edgedevice/logs` for logs from microservices on device
+
+All except `POST register` use device cert for mTLS.
+
+Every device has UUID by the CloudController and sent in the config (should be part of the API), sent in response to `GET config`, and used in all other requests by device. Message `message EdgeDevConfig` is the root of response to `/config`, UUID is in there.
+
+`GET /config` does not pass anything to controller, headers or trees or hashes or anything, right now, so every time we get the whole thing.
+
+### info posting
+
+Event triggered updates to state from device to controller, for different objects. Includes the following:
+
+* Updated version of baseos image
+* Partition switch
+* Application instance - application has Linux bridge - following lifecycle of application instance. 
+
+Look at messages in `zmet/*.proto`, specifically anything `ZInfo`.
+
+How often and what triggers is an implementation question; the definition of _what_ is reported is an API question.
+
+`Info` messages are intended to be reliable, and should not be lost. This is distinct from metrics.
+
+
+### metrics
+
+Metrics are numeric data points. Associated with apps, network instances or devices (similar to Info). One message sent periodically that carries all the metrics. It is sent once per frequency (implementation independent), root message is `message ZMetricMsg` is the root.
+
+Frequency is configured along with all other config variables/config items. The API is agnostic to them, just passes them along. The current list is [here](https://github.com/zededa/eve/blob/master/pkg/pillar/docs/global-config-variables.md).
+
+QUESTION: should these be part of the API? Or some?
+
+The message passes them along at `message ConfigItem`, which is a dumb key-value pair.
+
+### logs
+
+Logs are passed in groups of `message LogBundle`, which contain multiple `message LogEntry`. Combined for maximum size (any POST up to 64kB), plus timer, "do not wait longer than x seconds to send."
+
+Should be guaranteed delivery.
+
+Q: what if it runs out of memory or storage? Our log manager stores to loca disk, but this is a policy question.
+### registration
+
+Possible responses:
+
+```
+enum ZRegisterResult {
+        ZRegNone         = 0;
+        ZRegSuccess      = 1;
+        ZRegNotActive    = 2;
+        ZRegAlreadyDone  = 3;
+        ZRegDeviceNA     = 4;
+        ZRegFailed       = 5;
+}
+```
+
+Onboard message:
+
+```
+message ZRegisterMsg {
+       string onBoardKey = 1; // deprecated
+
+       bytes pemCert = 2;
+       string serial = 3;
+}
+```
+
+Flow is expected as follows:
+
+
+(this part should be kept private)
+
+1. New device manufactured, contains EVE image; OR existing device is flashed with EVE
+2. Manufacturer extracts unique cryptographic information from device, e.g. public key from tpm, or generate new public/private keypair and stores private on device
+3. Ship with those public keys on a separate medium - QR on box, label on box, USB key, email, printed paper - and send to end-user
+4. When device comes up, it registers with cloud controller. As we see it arrive on cloud controller, it shows up with public key information. Users can then choose which to accept.
+
+(end private)
+
+This leads to device registration:
+
+1. Device boots
+(assuming not yet registered)
+2. Device read config from `config` partition, which contains a `server` file, whose contents are an FQDN
+3. It finds a device certificate in `config` partition `device.cert` and `device.key` file, which contain the key/cert (code on way to use tpm)
+4. It finds an onboarding certificate in `config` partition `onboard.cert` and `onboard.key`, which contain the onboarding key/cert
+5. Connects via SSL to `https://<contents_of_server_file>/<endpoint listed above>`. In `config` partition, we have root CA cert we trust. Can use whatever they want.
+6. It does `POST device register` end point. Register endpoint uses onboarding cert for mTLS. 
+    * Can register any number of onboarding certs for my account (zedcloud capability) - unknown onboarding cert is rejected as `401` (`403`?)
+    * Once authenticated with mTLS, submits `ZRegisterMsg` message with unique device cert and serial number
+    * Can have any of the following:
+        * accepts: new device with serial number that has not been used before
+        * reject: serial number unknown (serial number has to be pre-registered in our implementation, but this is implementation-specific)
+        * reject: serial number already registered with different device
+    * How is the onboarding cert restricted to my account in the cloud controller? It is not now.
+    * When connected and auth-ed via mTLS, it then takes the serial+onboarding cert, uses them to find the customer, and now ties device to customer, unless serial already registered
+    * Map potential responses to http codes
+7. Once registration is accepted, record that it has been registered in `config` through files:
+    * Save the device certificate
+    * In process, create a file called `self-register-failed`, which exists until registration has succeeded. It is a transaction lock file.
+    * Create `failed` file, create device cert/key file, register, remove `-failed` file.
+    * Once successful, it is done
+
+
+#### Serial conflict resolution
+
+In theory serials can conflict between manufacturers, e.g. SuperMicro + RaspberryPi. We resolve it by having different onboarding certs per manufacturer, possibly manufacturer+customer (e.g. general SuperMicro, GE+SuperMicro, etc.)
+
+
+## Pillar local
+
+Is there a way to run pillar locally, not on a device?
+

--- a/api/README.md
+++ b/api/README.md
@@ -2,7 +2,7 @@
 
 This is the "Device API", for communications between an edge device and a controller.
 
-See https://www.lfedge.org/projects/eve/
+See [https://www.lfedge.org/projects/eve/](https://www.lfedge.org/projects/eve/)
 
 This directory defines only the API itself. It is in two parts:
 
@@ -12,4 +12,3 @@ This directory defines only the API itself. It is in two parts:
 To use the protobufs, you need to compile them into the target language of your choice, such as Go, Python or Node.
 The actual compiled language-specific libraries are in the [sdk/](../sdk/) in the root directory of this repository, and are compiled via the
 command `make sdk` in the root of this repository.
-

--- a/api/README.md
+++ b/api/README.md
@@ -1,9 +1,15 @@
-# api
-Device API in protobufs and/or json
+# Device API
 
-import as "github.com/zededa/api/zconfig" or "github.com/zededa/api/zmet"
-
-To build use make clean; make
-to avoid protobuf issues due to .go files from a previous build
+This is the "Device API", for communications between an edge device and a controller.
 
 See https://www.lfedge.org/projects/eve/
+
+This directory defines only the API itself. It is in two parts:
+
+* documentation in the file [API.md](./API.md) for the protocol
+* message definitions as [protobufs](https://developers.google.com/protocol-buffers/) in subdirectories to this directory
+
+To use the protobufs, you need to compile them into the target language of your choice, such as Go, Python or Node.
+The actual compiled language-specific libraries are in the [sdk/](../sdk/) in the root directory of this repository, and are compiled via the
+command `make sdk` in the root of this repository.
+

--- a/docs/REGISTRATION.md
+++ b/docs/REGISTRATION.md
@@ -1,0 +1,27 @@
+# Registration
+
+This document describes how an EVE device registers with a Controller on first boot. It complies with the official "Device API" available [here](../api/API.md).
+
+An EVE device, on boot, first determines if it already is registered, then, if it is not, runs the registration process.
+
+## Determine If Registration Is Necessary
+
+On boot, the device looks in `/config/` partition to determine if it has registered:
+
+* If no files `device.cert.pem` and `device.key.pem` exist, device has not registered, begin registration process in the next section.
+* If files `device.cert.pem` and `device.key.pem` exist and file `self-register-failed` exists, registration has potentially stalled mid-stream, continue registration process in the next section.
+* If no file `self-register-failed` exists, and files `device.cert.perm` and `device.key.pem` exist, device has registered, exit registration process.
+
+## Register If Necessary
+
+1. Device reads its configuration from `/config/` partition, which contain the following files:
+    * `server` - contents are the FQDN to the Controller for this Device
+    * `onboard.cert.pem` and `onboard.key.pem` - the onboarding public certificate and private key, respectively
+    * `root-certificate.pem` - the certificate of the CA that signed the Controller's certificate
+1. Device constructs all requests to `https://<contents_of_server_file>/<endpoint>`, for example, if contents of `server` are `api.zededa.com:885`, then the `ping` endpoint is at `https://api.zededa.com:885/api/v1/edgedevice/ping`
+1. Device creates a file in `/config/` partition named `self-register-failed`, with no contents, as a transactio lock file that registration is in process
+1. Device generate a unique device key and certificate and saves them to persistent location. As of this writing, it is in the `/config/` partition as `device.cert.pem` and `device.key.pem`. In the future, it may be in a tpm or other hardware key/certificate generation and storage mechanism.
+1. Device sends a `POST` request to the `register` endpoint, using the onboarding certificate for mTLS authentication, per the API, with body contents of a `ZRegistrerMsg`, including the device serial and device certificate in the message
+1. Once registration is accepted, Device removes from `/config/` partition file `self-register-failed`
+
+If registration fails, the device continues to retry to register. Since the controller might not yet have pre-registered the device's onboarding certificate or serial, retries provide it with the ability to eventually succeed.

--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -1,0 +1,24 @@
+# EVE go sdk
+
+SDK of generated message files for golang based on the protobuf message definitions in [api/](../../api/) in the root directory of this repository.
+
+To use:
+
+```go
+import (
+	"github.com/zededa/eve/sdk/zconfig"
+	"github.com/zededa/api/zmet"
+)
+```
+
+To build, go to the root directory of this repository and:
+
+```
+make sdk
+```
+
+You may have protobuf issues due to `.go` files in this directory and subdirectories from a previous build. To avoid that issue, run:
+
+```
+make clean-sdk
+```

--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -7,7 +7,7 @@ To use:
 ```go
 import (
 	"github.com/zededa/eve/sdk/zconfig"
-	"github.com/zededa/api/zmet"
+	"github.com/zededa/eve/sdk/zmet"
 )
 ```
 


### PR DESCRIPTION
This is the first draft of the "Device API". Note that it is a first draft, and requires cleanup, notably formatting, reducing duplication, style and others, specifically the `API.md` document.

It includes the following:

* Write an initial draft of the actual Device API in `api/API.md`
* Update `api/README.md` to reflect the proper relationship between and locations of protobufs, generated code and consumers
* Write the correct `README.md` in `sdk/README.md` and `sdk/go/README.md`
* Write `docs/REGISTRATION.md` which defines the EVE-specific boot process and how it interacts with a Controller via the Device API

